### PR TITLE
shutdown instance when transactor process exits

### DIFF
--- a/modules/transactor/files/run-transactor.sh
+++ b/modules/transactor/files/run-transactor.sh
@@ -28,4 +28,6 @@ license-key=${license-key}
 EOF
 chmod 744 aws.properties
 
-bin/transactor aws.properties
+bin/transactor aws.properties || true
+echo "Transactor process stopped. Shutting down."
+shutdown -h now


### PR DESCRIPTION
This addition will shutdown the instance when the transactor process exits, both in error or normal exit (whenever that may happen).

The result is that the instance will be in 'stopped' state and I believe because it is part of an autoscaling group it will eventually terminate. A new instance will automatically replace the old one.

This adds the same behavior as in the official Datomic AMI.

Maybe there are some potential improvements on the speed of instance replacement. I have the impression that when an instance gets terminated through the AWS Console or CLI, a new one is firing up faster than with the shutdown method used in this PR. It is probably possible to implement this, but this requires the correct IAM setup to be attached to the instance profile such that it can terminate itself. I'll have a look later, but this already works.