### PR TITLE
Add support for running a transactor in a vpc

### DIFF
--- a/modules/transactor/main.tf
+++ b/modules/transactor/main.tf
@@ -151,8 +151,8 @@ EOF
 
 # instance profile which assumes the transactor role
 resource "aws_iam_instance_profile" "transactor" {
-  name  = "${var.system_name}-datomic-transactor"
-  roles = ["${aws_iam_role.transactor.name}"]
+  name = "${var.system_name}-datomic-transactor"
+  role = "${aws_iam_role.transactor.name}"
 }
 
 # transactor launch config

--- a/modules/transactor/main.tf
+++ b/modules/transactor/main.tf
@@ -110,24 +110,6 @@ resource "aws_iam_role_policy" "transactor_logs" {
 EOF
 }
 
-# dynamodb table
-resource "aws_dynamodb_table" "table" {
-  count          = "${var.protocol == "ddb" ? 1 : 0}"
-  name           = "${var.aws_dynamodb_table}"
-  read_capacity  = "${var.aws_dynamodb_read_capacity}"
-  write_capacity = "${var.aws_dynamodb_write_capacity}"
-  hash_key       = "id"
-
-  attribute {
-    name = "id"
-    type = "S"
-  }
-
-  tags {
-    Name = "${var.system_name}"
-  }
-}
-
 # policy with complete access to the dynamodb table
 resource "aws_iam_role_policy" "transactor" {
   name  = "dynamo_access"
@@ -142,7 +124,7 @@ resource "aws_iam_role_policy" "transactor" {
         "dynamodb:*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:dynamodb:*:${var.aws_account_id}:table/${aws_dynamodb_table.table.name}"
+      "Resource": "arn:aws:dynamodb:*:${var.aws_account_id}:table/${var.aws_dynamodb_table}"
     }
   ]
 }

--- a/modules/transactor/main.tf
+++ b/modules/transactor/main.tf
@@ -147,7 +147,7 @@ resource "aws_launch_configuration" "transactor" {
   user_data            = "${data.template_file.transactor_user_data.rendered}"
   key_name             = "${var.key_name}"
 
-  #  associate_public_ip_address = true
+  associate_public_ip_address = true
 
   ephemeral_block_device {
     device_name  = "/dev/sdb"

--- a/modules/transactor/main.tf
+++ b/modules/transactor/main.tf
@@ -110,6 +110,24 @@ resource "aws_iam_role_policy" "transactor_logs" {
 EOF
 }
 
+# dynamodb table
+resource "aws_dynamodb_table" "table" {
+  count          = "${var.protocol == "ddb" ? 1 : 0}"
+  name           = "${var.aws_dynamodb_table}"
+  read_capacity  = "${var.aws_dynamodb_read_capacity}"
+  write_capacity = "${var.aws_dynamodb_write_capacity}"
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  tags {
+    Name = "${var.system_name}"
+  }
+}
+
 # policy with complete access to the dynamodb table
 resource "aws_iam_role_policy" "transactor" {
   name  = "dynamo_access"
@@ -124,7 +142,7 @@ resource "aws_iam_role_policy" "transactor" {
         "dynamodb:*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:dynamodb:*:${var.aws_account_id}:table/${var.aws_dynamodb_table}"
+      "Resource": "arn:aws:dynamodb:*:${var.aws_account_id}:table/${aws_dynamodb_table.table.name}"
     }
   ]
 }

--- a/modules/transactor/main.tf
+++ b/modules/transactor/main.tf
@@ -3,6 +3,8 @@ resource "aws_security_group" "datomic_inbound" {
   name        = "${var.system_name}_datomic_inbound"
   description = "Allow access to Datomic Transactor"
 
+  vpc_id  = "${var.vpc_id}"
+
   ingress {
     from_port   = 22
     to_port     = 22
@@ -192,6 +194,7 @@ resource "aws_autoscaling_group" "datomic_asg" {
   max_size             = "${var.instance_count}"
   min_size             = "${var.instance_count}"
   launch_configuration = "${aws_launch_configuration.transactor.name}"
+  vpc_zone_identifier  = ["${var.subnet_ids}"]
 
   tag {
     key                 = "Name"

--- a/modules/transactor/variables.tf
+++ b/modules/transactor/variables.tf
@@ -8,6 +8,13 @@ variable "system_name" {
   default = "datomic"
 }
 
+variable "vpc_id" {
+}
+
+variable "subnet_ids" {
+  type = "list"
+}
+
 variable "cidr" {}
 
 variable "transactor_instance_type" {

--- a/modules/transactor/variables.tf
+++ b/modules/transactor/variables.tf
@@ -83,6 +83,14 @@ variable "aws_dynamodb_region" {
   default = ""
 }
 
+variable "aws_dynamodb_read_capacity" {
+  default = 5
+}
+
+variable "aws_dynamodb_write_capacity" {
+  default = 5
+}
+
 variable "aws_account_id" {
   default = ""
 }

--- a/modules/transactor/variables.tf
+++ b/modules/transactor/variables.tf
@@ -83,14 +83,6 @@ variable "aws_dynamodb_region" {
   default = ""
 }
 
-variable "aws_dynamodb_read_capacity" {
-  default = 5
-}
-
-variable "aws_dynamodb_write_capacity" {
-  default = 5
-}
-
 variable "aws_account_id" {
   default = ""
 }


### PR DESCRIPTION
This PR adds support for running the datomic transactor in a specified aws vpc, instead of the default one. 

`vpc_id` and `subnet_ids` are now required variables without default values. Note when using [roll](https://github.com/juxt/roll) it is possible to use `(roll.utils/$ [:local :vpc-id])` and `(roll.utils/$ [:local :subnet-ids])` to reference the roll created vpc and subnets.

Launching into a non default vpc causes the launched instances to *not* have a public ip address assigned by default, this is desired behaviour but it does mean that the instances [don't have access to the internet](https://aws.amazon.com/premiumsupport/knowledge-center/create-attach-igw-vpc/), which is problematic when the datomic transactor tries to access S3 for log shipping. In order to resolve this in a simple way that is good enough most of the time, I have specified `associate_public_ip_address = true` in the launch configuration. It is also possible to resolve this by using an aws NAT to route the S3 traffic, but this is another layer of complexity. The default vpc does not have this issue since it always assigns public ip addresses by default.  